### PR TITLE
Add a name to the objective function in LP files

### DIFF
--- a/src/problem.rs
+++ b/src/problem.rs
@@ -121,7 +121,7 @@ impl LpFileFormat for LpProblem {
 
         let objective_string = || {
             if let Some(ref expr) = self.obj_expr {
-                expr.to_lp_file_format()
+                format!("obj: {}", expr.to_lp_file_format())
             } else {
                 String::new()
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,7 +75,7 @@ fn test_readme_example() {
     let output1 = "\\ One Problem
 
 Maximize
-  10 a + 20 b
+  obj: 10 a + 20 b
 
 Subject To
   c1: 500 a + 1200 b + 1500 c <= 10000


### PR DESCRIPTION
Hello,

This change aims to fix #5 by adding a name ("obj") to the objective function in LP files so Cbc can process them.

Best regards,
Thomas