### PR TITLE
Add tests for solvers output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,3 @@ pub mod solvers;
 pub mod variables;
 pub mod operations;
 
-#[cfg(test)]
-pub mod tests;
-

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -185,9 +185,9 @@ impl GlpkSolver {
                 Some(Ok(status_line)) => {
                     match &status_line[12..] {
                         "INTEGER OPTIMAL" | "OPTIMAL" => Status::Optimal,
-                        "INFEASIBLE (FINAL)" => Status::Infeasible,
-                        "INTEGER UNDEFINED" | "UNDEFINED" => Status::NotSolved,
-                        "UNBOUNDED" => Status::Unbounded,
+                        "INFEASIBLE (FINAL)" | "INTEGER EMPTY" => Status::Infeasible,
+                        "UNDEFINED" => Status::NotSolved,
+                        "INTEGER UNDEFINED" | "UNBOUNDED" => Status::Unbounded,
                         _ => return Err("Incorrect solution format".to_string())
                     }
                 },

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -96,6 +96,9 @@ impl CbcSolver {
     pub fn command_name(&self, command_name: String) -> CbcSolver {
         CbcSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
     }
+    pub fn temp_solution_file(&self, temp_solution_file: String) -> CbcSolver {
+        CbcSolver { name: self.name.clone(), command_name: self.command_name.clone(), temp_solution_file: temp_solution_file }
+    }
     pub fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
         fn read_specific_solution(f: &File) -> Result<(Status, HashMap<String, f32>), String> {
             let mut vars_value: HashMap<_, _> = HashMap::new();
@@ -150,6 +153,9 @@ impl GlpkSolver {
     }
     pub fn command_name(&self, command_name: String) -> GlpkSolver {
         GlpkSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
+    }
+    pub fn temp_solution_file(&self, temp_solution_file: String) -> GlpkSolver {
+        GlpkSolver { name: self.name.clone(), command_name: self.command_name.clone(), temp_solution_file: temp_solution_file }
     }
     pub fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
         fn read_specific_solution(f: &File) -> Result<(Status, HashMap<String, f32>), String> {

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -96,8 +96,7 @@ impl CbcSolver {
     pub fn command_name(&self, command_name: String) -> CbcSolver {
         CbcSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
     }
-
-    fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
+    pub fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
         fn read_specific_solution(f: &File) -> Result<(Status, HashMap<String, f32>), String> {
             let mut vars_value: HashMap<_, _> = HashMap::new();
 
@@ -152,7 +151,7 @@ impl GlpkSolver {
     pub fn command_name(&self, command_name: String) -> GlpkSolver {
         GlpkSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
     }
-    fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
+    pub fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
         fn read_specific_solution(f: &File) -> Result<(Status, HashMap<String, f32>), String> {
             fn read_size(line: Option<Result<String, Error>>) -> Result<usize, String> {
                 match line {

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -1,8 +1,10 @@
-use variables::*;
-use variables::LpExpression::*;
+extern crate lp_modeler;
+
+use lp_modeler::variables::*;
+use lp_modeler::variables::LpExpression::*;
 use std::rc::Rc;
-use operations::LpOperations;
-use problem::LpFileFormat;
+use lp_modeler::operations::LpOperations;
+use lp_modeler::problem::LpFileFormat;
 
 
 #[test]
@@ -116,10 +118,10 @@ fn expressions_to_lp_file_format() {
 
 #[test]
 fn test_readme_example() {
-    use problem::{LpObjective, LpProblem};
-    use operations::{LpOperations};
-    use variables::LpInteger;
-    use solvers::{SolverTrait, CbcSolver};
+    use lp_modeler::problem::{LpObjective, LpProblem};
+    use lp_modeler::operations::{LpOperations};
+    use lp_modeler::variables::LpInteger;
+    use lp_modeler::solvers::{SolverTrait, CbcSolver};
 
     let ref a = LpInteger::new("a");
     let ref b = LpInteger::new("b");

--- a/tests/solution_files/cbc_infeasible.sol
+++ b/tests/solution_files/cbc_infeasible.sol
@@ -1,0 +1,4 @@
+Infeasible - objective value -100.00000000
+      0 a                      4                      0
+      1 b                      3                      0
+      2 c                      0                     10

--- a/tests/solution_files/cbc_optimal.sol
+++ b/tests/solution_files/cbc_optimal.sol
@@ -1,0 +1,4 @@
+Optimal - objective value -170.00000000
+      0 a                      5                    -10
+      1 b                      6                    -20
+      2 c                      0                      0

--- a/tests/solution_files/cbc_unbounded.sol
+++ b/tests/solution_files/cbc_unbounded.sol
@@ -1,0 +1,4 @@
+Unbounded - objective value 0.00000000
+      0 a                      0                    -10
+      1 b                      0                    -20
+      2 c                      0                      0

--- a/tests/solution_files/glpk_infeasible.sol
+++ b/tests/solution_files/glpk_infeasible.sol
@@ -1,0 +1,31 @@
+Problem:    
+Rows:       4
+Columns:    3 (3 integer, 0 binary)
+Non-zeros:  10
+Status:     INTEGER EMPTY
+Objective:  obj = 0 (MAXimum)
+
+   No.   Row name        Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 c1                          0                       10000 
+     2 c2                          0                          10 
+     3 c3                          0                           0 
+     4 c4                          0             1               
+
+   No. Column name       Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 a            *              0             0               
+     2 b            *              0             0               
+     3 c            *              0             0               
+
+Integer feasibility conditions:
+
+KKT.PE: max.abs.err = 0.00e+00 on row 0
+        max.rel.err = 0.00e+00 on row 0
+        High quality
+
+KKT.PB: max.abs.err = 1.00e+00 on row 4
+        max.rel.err = 5.00e-01 on row 4
+        SOLUTION IS INFEASIBLE
+
+End of output

--- a/tests/solution_files/glpk_optimal.sol
+++ b/tests/solution_files/glpk_optimal.sol
@@ -1,0 +1,30 @@
+Problem:    
+Rows:       3
+Columns:    3 (3 integer, 0 binary)
+Non-zeros:  8
+Status:     INTEGER OPTIMAL
+Objective:  obj = 100 (MAXimum)
+
+   No.   Row name        Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 c1                       6000                       10000 
+     2 c2                         10                          10 
+     3 c3                         -5                           0 
+
+   No. Column name       Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 a            *              0             0               
+     2 b            *              5             0               
+     3 c            *              0             0               
+
+Integer feasibility conditions:
+
+KKT.PE: max.abs.err = 0.00e+00 on row 0
+        max.rel.err = 0.00e+00 on row 0
+        High quality
+
+KKT.PB: max.abs.err = 0.00e+00 on row 0
+        max.rel.err = 0.00e+00 on row 0
+        High quality
+
+End of output

--- a/tests/solution_files/glpk_unbounded.sol
+++ b/tests/solution_files/glpk_unbounded.sol
@@ -1,0 +1,28 @@
+Problem:    
+Rows:       1
+Columns:    3 (3 integer, 0 binary)
+Non-zeros:  2
+Status:     INTEGER UNDEFINED
+Objective:  obj = 0 (MAXimum)
+
+   No.   Row name        Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 c3                          0                           0 
+
+   No. Column name       Activity     Lower bound   Upper bound
+------ ------------    ------------- ------------- -------------
+     1 a            *              0             0               
+     2 b            *              0             0               
+     3 c            *              0             0               
+
+Integer feasibility conditions:
+
+KKT.PE: max.abs.err = 0.00e+00 on row 0
+        max.rel.err = 0.00e+00 on row 0
+        High quality
+
+KKT.PB: max.abs.err = 0.00e+00 on row 0
+        max.rel.err = 0.00e+00 on row 0
+        High quality
+
+End of output

--- a/tests/solvers.rs
+++ b/tests/solvers.rs
@@ -1,0 +1,66 @@
+extern crate lp_modeler;
+
+use lp_modeler::solvers::CbcSolver;
+use lp_modeler::solvers::GlpkSolver;
+use lp_modeler::solvers::Status;
+use std::fs;
+
+#[test]
+fn cbc_optimal() {
+    let _ = fs::copy("tests/solution_files/cbc_optimal.sol", "cbc_optimal.sol");
+    let solver = CbcSolver::new();
+    let solver2 = solver.temp_solution_file("cbc_optimal.sol".to_string());
+    let (status, mut variables) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Optimal);
+    assert_eq!(variables.remove("a"), Some(5f32));
+    assert_eq!(variables.remove("b"), Some(6f32));
+    assert_eq!(variables.remove("c"), Some(0f32));
+}
+
+#[test]
+fn cbc_infeasible() {
+    let _ = fs::copy("tests/solution_files/cbc_infeasible.sol", "cbc_infeasible.sol");
+    let solver = CbcSolver::new();
+    let solver2 = solver.temp_solution_file("cbc_infeasible.sol".to_string());
+    let (status, _) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Infeasible);
+}
+
+#[test]
+fn cbc_unbounded() {
+    let _ = fs::copy("tests/solution_files/cbc_unbounded.sol", "cbc_unbounded.sol");
+    let solver = CbcSolver::new();
+    let solver2 = solver.temp_solution_file("cbc_unbounded.sol".to_string());
+    let (status, _) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Unbounded);
+}
+
+#[test]
+fn glpk_optimal() {
+    let _ = fs::copy("tests/solution_files/glpk_optimal.sol", "glpk_optimal.sol");
+    let solver = GlpkSolver::new();
+    let solver2 = solver.temp_solution_file("glpk_optimal.sol".to_string());
+    let (status, mut variables) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Optimal);
+    assert_eq!(variables.remove("a"), Some(0f32));
+    assert_eq!(variables.remove("b"), Some(5f32));
+    assert_eq!(variables.remove("c"), Some(0f32));
+}
+
+#[test]
+fn glpk_infeasible() {
+    let _ = fs::copy("tests/solution_files/glpk_infeasible.sol", "glpk_infeasible.sol");
+    let solver = GlpkSolver::new();
+    let solver2 = solver.temp_solution_file("glpk_infeasible.sol".to_string());
+    let (status, _) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Infeasible);
+}
+
+#[test]
+fn glpk_unbounded() {
+    let _ = fs::copy("tests/solution_files/glpk_unbounded.sol", "glpk_unbounded.sol");
+    let solver = GlpkSolver::new();
+    let solver2 = solver.temp_solution_file("glpk_unbounded.sol".to_string());
+    let (status, _) = solver2.read_solution().unwrap();
+    assert_eq!(status, Status::Unbounded);
+}


### PR DESCRIPTION
Hello,

Following discussions on #13 , here is an attempt to add some tests for the parsing of output files from GLPK and Cbc. Not all cases are covered but it's a start.

Comments are very welcome, especially about the addition of `temp_solution_file` functions, as I am not sure this was the best way to set custom names for solution files.

Best regards,
Thomas