### PR TITLE
Fix for failing builds: unique filenames

### DIFF
--- a/src/problem.rs
+++ b/src/problem.rs
@@ -66,7 +66,7 @@ pub trait Problem {
 /// ```
 #[derive(Debug)]
 pub struct LpProblem {
-    name: &'static str,
+    pub name: &'static str,
     objective_type: LpObjective,
     obj_expr: Option<LpExpression>,
     constraints: Vec<LpConstraint>

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -235,7 +235,7 @@ impl SolverTrait for GurobiSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model = "test.lp";
+        let file_model = &format!("{}.lp", problem.name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {
@@ -264,7 +264,7 @@ impl SolverTrait for CbcSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model = "test.lp";
+        let file_model = &format!("{}.lp", problem.name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {
@@ -288,7 +288,7 @@ impl SolverTrait for GlpkSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model:&str = "test.lp";
+        let file_model = &format!("{}.lp", problem.name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -20,7 +20,7 @@ fn test_readme_example_1() {
     problem += (500*a + 1200*b + 1500*c).le(10000);
     problem += (a).le(b);
 
-    let solver = CbcSolver::new();
+    let solver = CbcSolver::new().temp_solution_file(format!("{}.sol", problem.name));
 
     match solver.run(&problem) {
         Ok((status, res)) => {
@@ -115,7 +115,7 @@ fn test_readme_example_2() {
     // }
 
     // Run Solver
-    let solver = CbcSolver::new();
+    let solver = CbcSolver::new().temp_solution_file(format!("{}.sol", problem.name));
     let result = solver.run(&problem);
 
     // Terminate if error, or assign status & variable values


### PR DESCRIPTION
@jcavat After some digging into these half-passing/half-failing tests, I discovered the issue is simply in the lp model & solution filenames. Since cargo runs tests in parallel, this creates possibilities for race conditions and loading the solution file from another test (when all called "sol.sol" by default). The previous PR simply exposed this issue by adding another test which interacted with the solver.

This PR changes the example code to use the problem name as a filename for the lp model and solution. A more trivial way to mask this would be confining cargo tests to using only 1 thread. Ideally in the future each model should use a UUID filename to interact with the solver.

I believe this should fix the flaky builds.