### PR TITLE
Use UUID for IO files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: rust
 rust:
-  - 1.11.0
-  - 1.13.0
-  - 1.16.0
-  - 1.17.0
-  - 1.20.0
+  - 1.22.0
+  - 1.24.0
+  - 1.26.0
+  - 1.28.0
 
 before_install:
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ exclude = [
 travis-ci = { repository = "jcavat/rust-lp-modeler" }
 appveyor = { repository = "jcavat/rust-lp-modeler" }
 
+[dependencies]
+uuid = { version = "0.6", features = ["v4"] }

--- a/src/problem.rs
+++ b/src/problem.rs
@@ -1,3 +1,5 @@
+extern crate uuid;
+
 use std;
 use variables::*;
 use variables::LpExpression::*;
@@ -10,6 +12,8 @@ use std::io::prelude::*;
 use std::ops::{AddAssign};
 
 //use std::collections::HashMap;
+
+use self::uuid::Uuid;
 
 /// Enum helping to specify the objective function of the linear problem.
 ///
@@ -67,6 +71,7 @@ pub trait Problem {
 #[derive(Debug)]
 pub struct LpProblem {
     pub name: &'static str,
+    pub unique_name: String,
     objective_type: LpObjective,
     obj_expr: Option<LpExpression>,
     constraints: Vec<LpConstraint>
@@ -76,7 +81,8 @@ pub struct LpProblem {
 impl LpProblem {
     /// Create a new problem
     pub fn new(name: &'static str, objective: LpObjective) -> LpProblem {
-        LpProblem { name: name, objective_type: objective, obj_expr: None, constraints: Vec::new() }
+        let unique_name = format!("{}_{}", name, Uuid::new_v4());
+        LpProblem { name: name, unique_name: unique_name, objective_type: objective, obj_expr: None, constraints: Vec::new() }
     }
 
     // TODO: Call once and pass into parameter

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -241,7 +241,7 @@ impl SolverTrait for GurobiSolver {
 
         match problem.write_lp(file_model) {
             Ok(_) => {
-                match Command::new(&self.command_name).arg(format!("ResultFile={}", self.temp_solution_file)).arg(file_model).output() {
+                let result = match Command::new(&self.command_name).arg(format!("ResultFile={}", self.temp_solution_file)).arg(file_model).output() {
                     Ok(r) => {
                         let mut status = Status::SubOptimal;
                         if String::from_utf8(r.stdout).expect("").contains("Optimal solution found") {
@@ -255,7 +255,10 @@ impl SolverTrait for GurobiSolver {
                         }
                     },
                     Err(_) => Err(format!("Error running the {} solver", self.name)),
-                }
+                };
+                let _ = fs::remove_file(&file_model);
+
+                result
             },
             Err(e) => Err(e.to_string()),
         }
@@ -270,7 +273,7 @@ impl SolverTrait for CbcSolver {
 
         match problem.write_lp(file_model) {
             Ok(_) => {
-                match Command::new(&self.command_name).arg(file_model).arg("solve").arg("solution").arg(&self.temp_solution_file).output() {
+                let result = match Command::new(&self.command_name).arg(file_model).arg("solve").arg("solution").arg(&self.temp_solution_file).output() {
                     Ok(r) => {
                         if r.status.success(){
                             self.read_solution()
@@ -279,7 +282,10 @@ impl SolverTrait for CbcSolver {
                         }
                     },
                     Err(_) => Err(format!("Error running the {} solver", self.name)),
-                }
+                };
+                let _ = fs::remove_file(&file_model);
+
+                result
             },
             Err(e) => Err(e.to_string()),
         }
@@ -294,7 +300,7 @@ impl SolverTrait for GlpkSolver {
 
         match problem.write_lp(file_model) {
             Ok(_) => {
-                match Command::new(&self.command_name).arg("--lp").arg(file_model).arg("-o").arg(&self.temp_solution_file).output() {
+                let result = match Command::new(&self.command_name).arg("--lp").arg(file_model).arg("-o").arg(&self.temp_solution_file).output() {
                     Ok(r) => {
                         if r.status.success() {
                             self.read_solution()
@@ -303,7 +309,10 @@ impl SolverTrait for GlpkSolver {
                         }
                     },
                     Err(_) => Err(format!("Error running the {} solver", self.name)),
-                }
+                };
+                let _ = fs::remove_file(&file_model);
+
+                result
             },
             Err(e) => Err(e.to_string()),
         }

--- a/src/solvers.rs
+++ b/src/solvers.rs
@@ -1,3 +1,6 @@
+extern crate uuid;
+use self::uuid::Uuid;
+
 use std::fs;
 use std::io::prelude::*;
 use std::process::Command;
@@ -7,7 +10,6 @@ use problem::{LpProblem, Problem};
 use problem::{LpFileFormat};
 use std::fs::File;
 use std::io::Error;
-
 
 #[derive(Debug, PartialEq)]
 pub enum Status {
@@ -41,7 +43,7 @@ pub struct GlpkSolver {
 
 impl GurobiSolver {
     pub fn new() -> GurobiSolver {
-        GurobiSolver { name: "Gurobi".to_string(), command_name: "gurobi_cl".to_string(), temp_solution_file: "sol.sol".to_string() }
+        GurobiSolver { name: "Gurobi".to_string(), command_name: "gurobi_cl".to_string(), temp_solution_file: format!("{}.sol", Uuid::new_v4().to_string()) }
     }
     pub fn command_name(&self, command_name: String) -> GurobiSolver {
         GurobiSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
@@ -91,7 +93,7 @@ impl GurobiSolver {
 }
 impl CbcSolver {
     pub fn new() -> CbcSolver {
-        CbcSolver { name: "Cbc".to_string(), command_name: "cbc".to_string(), temp_solution_file: "sol.sol".to_string() }
+        CbcSolver { name: "Cbc".to_string(), command_name: "cbc".to_string(), temp_solution_file: format!("{}.sol", Uuid::new_v4().to_string()) }
     }
     pub fn command_name(&self, command_name: String) -> CbcSolver {
         CbcSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
@@ -149,7 +151,7 @@ impl CbcSolver {
 }
 impl GlpkSolver {
     pub fn new() -> GlpkSolver {
-        GlpkSolver { name: "Glpk".to_string(), command_name: "glpsol".to_string(), temp_solution_file: "sol.sol".to_string() }
+        GlpkSolver { name: "Glpk".to_string(), command_name: "glpsol".to_string(), temp_solution_file: format!("{}.sol", Uuid::new_v4().to_string()) }
     }
     pub fn command_name(&self, command_name: String) -> GlpkSolver {
         GlpkSolver { name: self.name.clone(), command_name: command_name, temp_solution_file: self.temp_solution_file.clone() }
@@ -235,7 +237,7 @@ impl SolverTrait for GurobiSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model = &format!("{}.lp", problem.name);
+        let file_model = &format!("{}.lp", problem.unique_name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {
@@ -264,7 +266,7 @@ impl SolverTrait for CbcSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model = &format!("{}.lp", problem.name);
+        let file_model = &format!("{}.lp", problem.unique_name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {
@@ -288,7 +290,7 @@ impl SolverTrait for GlpkSolver {
     type P = LpProblem;
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String,f32>), String> {
 
-        let file_model = &format!("{}.lp", problem.name);
+        let file_model = &format!("{}.lp", problem.unique_name);
 
         match problem.write_lp(file_model) {
             Ok(_) => {

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -20,7 +20,7 @@ fn test_readme_example_1() {
     problem += (500*a + 1200*b + 1500*c).le(10000);
     problem += (a).le(b);
 
-    let solver = CbcSolver::new().temp_solution_file(format!("{}.sol", problem.name));
+    let solver = CbcSolver::new();
 
     match solver.run(&problem) {
         Ok((status, res)) => {
@@ -115,7 +115,7 @@ fn test_readme_example_2() {
     // }
 
     // Run Solver
-    let solver = CbcSolver::new().temp_solution_file(format!("{}.sol", problem.name));
+    let solver = CbcSolver::new();
     let result = solver.run(&problem);
 
     // Terminate if error, or assign status & variable values


### PR DESCRIPTION
This PR addresses Issue #19.
- Problem LP files are now named "<problem_name>_<UUID>.lp"
- Temporary solution files are now named "<UUID>.sol" by default

This allows removal of the workaround/hack required of users code where specification of different temporary solution filenames were required for parallel tests to run. This change is made in tests/problems.rs.

A side-effect is that this creates many .lp files in the directory (a new file for each run), so these are now made temporary. (Persisting the .lp file can still be achieved simply by calling the "problem.write_lp" function, as shown in documentation.)

A second side-effect is that the dependency module for generating UUIDs requires at least rustc version 1.18, and will soon be changed to 1.22. This PR proposes an according increase in the minimum rust version for this package, as reflected in the .travis.yml file.