### PR TITLE
Don't fail on infeasible solution

### DIFF
--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -62,7 +62,10 @@ impl CbcSolver {
             };
             for line in file.lines() {
                 let l = line.unwrap();
-                let result_line: Vec<_> = l.split_whitespace().collect();
+                let mut result_line: Vec<_> = l.split_whitespace().collect();
+                if result_line[0] == "**" {
+                    result_line.remove(0);
+                };
                 if result_line.len() == 4 {
                     match result_line[2].parse::<f32>() {
                         Ok(n) => {

--- a/tests/solution_files/cbc_infeasible_alternative_format.sol
+++ b/tests/solution_files/cbc_infeasible_alternative_format.sol
@@ -1,0 +1,3 @@
+Infeasible - objective value 2.00000000
+**       0 a                      2                       0
+      1 b                      0                       0

--- a/tests/solvers.rs
+++ b/tests/solvers.rs
@@ -30,6 +30,30 @@ fn cbc_infeasible() {
 }
 
 #[test]
+// created from:
+// minimize
+//   obj: a + b
+// subject to
+//   c1: a + b <= 1
+//   c2: a + b >= 2
+// binaries
+//   a b
+// end
+fn cbc_infeasible_alternative_format() {
+    let _ = fs::copy(
+        "tests/solution_files/cbc_infeasible_alternative_format.sol",
+        "cbc_infeasible_alternative_format.sol",
+    );
+    let (status, mut variables) = CbcSolver::new()
+        .temp_solution_file("cbc_infeasible_alternative_format.sol".to_string())
+        .read_solution()
+        .unwrap();
+    assert_eq!(status, Status::Infeasible);
+    assert_eq!(variables.remove("a"), Some(2f32));
+    assert_eq!(variables.remove("b"), Some(0f32));
+}
+
+#[test]
 fn cbc_unbounded() {
     let _ = fs::copy(
         "tests/solution_files/cbc_unbounded.sol",


### PR DESCRIPTION
When the problem contains contradicting constraints, the output for an
infeasible solution marks certain lines with leading '**'. This made the
parsing fail as the number of elements per line of the solution file
isn't 4 anymore.

This fixes #27.