### PR TITLE
Allow setting threads and seconds for CBC

### DIFF
--- a/src/solvers/cbc.rs
+++ b/src/solvers/cbc.rs
@@ -15,6 +15,7 @@ pub struct CbcSolver {
     name: String,
     command_name: String,
     temp_solution_file: String,
+    params: HashMap<String, String>,
 }
 
 impl CbcSolver {
@@ -23,22 +24,48 @@ impl CbcSolver {
             name: "Cbc".to_string(),
             command_name: "cbc".to_string(),
             temp_solution_file: format!("{}.sol", Uuid::new_v4().to_string()),
+            params: Default::default(),
         }
     }
+
     pub fn command_name(&self, command_name: String) -> CbcSolver {
         CbcSolver {
             name: self.name.clone(),
             command_name,
             temp_solution_file: self.temp_solution_file.clone(),
+            params: self.params.clone(),
         }
     }
+
     pub fn temp_solution_file(&self, temp_solution_file: String) -> CbcSolver {
         CbcSolver {
             name: self.name.clone(),
             command_name: self.command_name.clone(),
             temp_solution_file,
+            params: self.params.clone(),
         }
     }
+
+    pub fn seconds(&self, seconds: f32) -> CbcSolver {
+        self.add_param("seconds".to_owned(), seconds.to_string())
+    }
+
+    pub fn threads(&self, threads: u32) -> CbcSolver {
+        self.add_param("threads".to_owned(), threads.to_string())
+    }
+
+    fn add_param(&self, name: String, value: String) -> CbcSolver {
+        let mut new_params = self.params.clone();
+        new_params.insert(name, value);
+
+        CbcSolver {
+            name: self.name.clone(),
+            command_name: self.command_name.clone(),
+            temp_solution_file: self.temp_solution_file.clone(),
+            params: new_params,
+        }
+    }
+
     pub fn read_solution(&self) -> Result<(Status, HashMap<String, f32>), String> {
         fn read_specific_solution(f: &File) -> Result<(Status, HashMap<String, f32>), String> {
             let mut vars_value: HashMap<_, _> = HashMap::new();
@@ -93,33 +120,28 @@ impl CbcSolver {
 
 impl SolverTrait for CbcSolver {
     type P = LpProblem;
+
     fn run(&self, problem: &Self::P) -> Result<(Status, HashMap<String, f32>), String> {
-        let file_model = &format!("{}.lp", problem.unique_name);
+        let file_model = format!("{}.lp", problem.unique_name);
+        problem.write_lp(&file_model).map_err(|e| e.to_string())?;
 
-        match problem.write_lp(file_model) {
-            Ok(_) => {
-                let result = match Command::new(&self.command_name)
-                    .arg(file_model)
-                    .arg("solve")
-                    .arg("solution")
-                    .arg(&self.temp_solution_file)
-                    .output()
-                    {
-                        Ok(r) => {
-                            if r.status.success() {
-                                self.read_solution()
-                            } else {
-                                Err(r.status.to_string())
-                            }
-                        }
-                        Err(_) => Err(format!("Error running the {} solver", self.name)),
-                    };
-                let _ = fs::remove_file(&file_model);
+        let result = Command::new(&self.command_name)
+            .arg(&file_model)
+            .args(self.params.iter().flat_map(|(k, v)| vec![k, v]))
+            .arg("solve")
+            .arg("solution")
+            .arg(&self.temp_solution_file)
+            .output()
+            .map_err(|_| format!("Error running the {} solver", self.name))
+            .and_then(|r| {
+                if r.status.success() {
+                    self.read_solution()
+                } else {
+                    Err(r.status.to_string())
+                }
+            });
 
-                result
-            }
-            Err(e) => Err(e.to_string()),
-        }
+        let _ = fs::remove_file(file_model);
+        result
     }
 }
-


### PR DESCRIPTION
I needed a way to speed up calculations and also restrict the total runtime of the optimization for the CBC solver. I've opted for a generic approach (first used specific fields in `LpProblem`, but this approach will create a lot of boilerplate in the long run) as this seems to be easily extendable for other options.

I also took the opportunity to refactor `SolverTrait::run` for `CbcSolver` to use `?` instead of nested `match` (I can revert these changes if they're undesired).