### PR TITLE
add ToTokens implementations for quoting Lp structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ appveyor = { repository = "jcavat/rust-lp-modeler" }
 
 [dependencies]
 uuid = { version = "0.7.4", features = ["v4"] }
+quote = "1"
+proc-macro2 = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate uuid;
+extern crate proc_macro2;
+extern crate quote;
 
 pub mod util;
 
@@ -16,4 +18,3 @@ pub mod format {
 }
 
 pub mod solvers;
-

--- a/tests/quote.rs
+++ b/tests/quote.rs
@@ -1,0 +1,32 @@
+extern crate lp_modeler;
+extern crate quote;
+use quote::quote;
+
+use lp_modeler::dsl::*;
+
+#[test]
+fn test_quotations() {
+  use LpExpression::*;
+  let a = LpInteger { name : "a" . to_string ( ) , lower_bound : None , upper_bound : None };
+  let quoted_a = quote!(#a);
+  let quoted_a_str = "LpInteger { name : \"a\" . to_string ( ) , lower_bound : None , upper_bound : None }";
+  assert_eq!(quoted_a.to_string(), quoted_a_str);
+
+  let exp : LpExpression = a.clone().into();
+  let quoted_exp = quote!(#exp);
+  let quoted_exp_str = "LpExpression :: ConsInt ( ".to_owned() + quoted_a_str + " )";
+  assert_eq!(quoted_exp.to_string(), quoted_exp_str);
+
+  let full_exp = LpExpression::MulExpr ( Box::new ( LpExpression::SubExpr ( Box::new ( LpExpression::EmptyExpr ) , Box::new ( LpExpression::LitVal ( 1f32 ) ) ) ) , Box::new ( LpExpression::AddExpr ( Box::new ( LpExpression::ConsCont ( LpContinuous { name : "x".to_string() , lower_bound : None , upper_bound : None } ) ) , Box::new ( LpExpression::ConsInt ( LpInteger { name : "y".to_string() , lower_bound : None , upper_bound : None } ) ) ) ) );
+
+  let full_exp_quoted = quote!(#full_exp);
+  let full_exp_str = "LpExpression :: MulExpr ( Box :: new ( LpExpression :: SubExpr ( Box :: new ( LpExpression :: EmptyExpr ) , Box :: new ( LpExpression :: LitVal ( 1f32 ) ) ) ) , Box :: new ( LpExpression :: AddExpr ( Box :: new ( LpExpression :: ConsCont ( LpContinuous { name : \"x\" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) , Box :: new ( LpExpression :: ConsInt ( LpInteger { name : \"y\" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) ) ) )";
+  assert_eq!(full_exp_quoted.to_string(), full_exp_str);
+
+  // a.equal(&b);
+  let a_eq_b = LpConstraint( SubExpr( Box::new ( ConsInt ( LpInteger { name : "a" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) , Box::new ( ConsInt ( LpInteger { name : "b" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) ) , Constraint::Equal , LitVal(0f32));
+
+  let quoted_a_eq_b = quote!(#a_eq_b);
+  let a_eq_b_str = "LpConstraint ( LpExpression :: SubExpr ( Box :: new ( LpExpression :: ConsInt ( LpInteger { name : \"a\" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) , Box :: new ( LpExpression :: ConsInt ( LpInteger { name : \"b\" . to_string ( ) , lower_bound : None , upper_bound : None } ) ) ) , Constraint :: Equal , LpExpression :: LitVal ( 0f32 ) )";
+  assert_eq!(quoted_a_eq_b.to_string(), a_eq_b_str)
+}


### PR DESCRIPTION
Hi! I have a bit of an auxiliary PR here.

I am working on a [syntax extension](https://doc.rust-lang.org/1.2.0/book/compiler-plugins.html) crate which translates a declarative language into Rust code. A part of that language is declaring constraints on individual items, which get accumulated together into an LP problem, based on which parts of the syntax was used.

Long-story short, I would like the ability to `quote!()` all structs in the lp-modeler crate, so that I can automatically generate rust sources with LP logic in them. This PR takes a first stab at that, and I am not a fan of the intrusive new dependencies -- but still not sure if there is a better practice, e.g. hiding behind a feature flag. What I think I know is that  [ToTokens](https://docs.rs/quote/1.0.2/quote/trait.ToTokens.html) implementations belong in the crate defining the struct, hence the PR here.

Still testing with my local project, will add a couple of more comments later this week.