### PR TITLE
Adding intoexpr operations for binary and continuous

### DIFF
--- a/src/dsl/operations.rs
+++ b/src/dsl/operations.rs
@@ -91,9 +91,16 @@ macro_rules! lpvars_operation_for_intoexpr {
         }
     };
 }
+
+lpvars_operation_for_intoexpr!(Mul, mul, LpBinary, MulExpr, ConsBin);
+lpvars_operation_for_intoexpr!(Add, add, LpBinary, AddExpr, ConsBin);
+lpvars_operation_for_intoexpr!(Sub, sub, LpBinary, SubExpr, ConsBin);
 lpvars_operation_for_intoexpr!(Mul, mul, LpInteger, MulExpr, ConsInt);
 lpvars_operation_for_intoexpr!(Add, add, LpInteger, AddExpr, ConsInt);
 lpvars_operation_for_intoexpr!(Sub, sub, LpInteger, SubExpr, ConsInt);
+lpvars_operation_for_intoexpr!(Mul, mul, LpContinuous, MulExpr, ConsCont);
+lpvars_operation_for_intoexpr!(Add, add, LpContinuous, AddExpr, ConsCont);
+lpvars_operation_for_intoexpr!(Sub, sub, LpContinuous, SubExpr, ConsCont);
 
 /// Macro implementing binary operations for a numeric type
 macro_rules! numeric_operation_for_expr {

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -35,6 +35,15 @@ fn distributivity() {
         ((c + 10) * test2).to_lp_file_format(),
         "6 c a + 3 c a b + 60 a + 30 a b"
     );
+
+    let ref x = LpContinuous::new("x");
+    let ref y = LpContinuous::new("y");
+    let ref z = LpContinuous::new("z");
+
+    let test3 = x * (y - z);
+    assert_eq!((3 * (3 - a)).to_lp_file_format(), "-3 a + 9");
+    assert_eq!(test3.to_lp_file_format(), "x y - x z");
+    assert_eq!((4 * test3).to_lp_file_format(), "4 x y - 4 x z");
 }
 
 #[test]
@@ -57,6 +66,11 @@ fn associativity() {
 
     assert_eq!((a - (b - 2) + c).to_lp_file_format(), "a - b + c + 2");
     assert_eq!(((a - b) - 2 + c).to_lp_file_format(), "a - b + c - 2");
+
+    let ref x = LpBinary::new("x");
+    let ref y = LpBinary::new("y");
+    assert_eq!((x + (y + 1)).to_lp_file_format(), "x + y + 1");
+    assert_eq!(((x + y) + 1).to_lp_file_format(), "x + y + 1");
 }
 
 #[test]


### PR DESCRIPTION
Hey @jcavat,

Thanks for the package, great stuff!

When using `LpContinuous` variables, I got an error suggesting that Add / Mul hadn't been implemented. For example:

```rust
fn main() {
    let mut problem = LpProblem::new("ShiftPlanning", LpObjective::Minimize);

    let ref a = LpContinuous {
        name: "a".to_string(),
        lower_bound: Some(0.0),
        upper_bound: Some(10.0)
    };

    let ref b = LpContinuous {
        name: "b".to_string(),
        lower_bound: Some(0.0),
        upper_bound: Some(10.0)
    };

    problem += (a).ge(b * 1.0 + 3);
...
```
Was failing at `b * 1.0`, and also if the line is just `(a).ge(b + 3)`. Of course here this is a bit contrived, but I had real examples that it made sense for.

The commit here seemed to be the way to solve, and indeed allows the code to work. I'm new to Rust, so hopefully I'm not miles off-base here. I wasn't 100% sure about binary though.