### PR TITLE
Feature: native coin-or solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ travis-ci = { repository = "jcavat/rust-lp-modeler" }
 appveyor = { repository = "jcavat/rust-lp-modeler" }
 
 [dependencies]
+coin_cbc = "0.1.0"
 uuid = { version = "0.7.4", features = ["v4"] }
 quote = "1"
 proc-macro2 = "1.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - ps: Start-FileDownload "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -FileName "C:\Cbc\Cbc-2.9.zip"
   - 7z x C:\Cbc\Cbc-2.9.zip -o"C:\Cbc\"
   - SET PATH=%PATH%;C:\Cbc\bin
-  - SET PATH=%PATH%;C:\Cbc\lib
+  - SET LIB=%LIB%;C:\Cbc\lib
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ install:
   - ps: Start-FileDownload "https://bintray.com/coin-or/download/download_file?file_path=Cbc-2.9-win32-msvc14.zip" -FileName "C:\Cbc\Cbc-2.9.zip"
   - 7z x C:\Cbc\Cbc-2.9.zip -o"C:\Cbc\"
   - SET PATH=%PATH%;C:\Cbc\bin
+  - SET PATH=%PATH%;C:\Cbc\lib
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate uuid;
 extern crate proc_macro2;
 extern crate quote;
+extern crate coin_cbc;
 
 pub mod util;
 

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -10,6 +10,9 @@ pub use self::gurobi::*;
 
 pub mod glpk;
 pub use self::glpk::*;
+
+pub mod native_cbc;
+pub use self::native_cbc::*;
 use std::fs::File;
 use std::fs;
 use util::is_zero;
@@ -115,4 +118,3 @@ pub trait WithNbThreads<T> {
     fn nb_threads(&self) -> Option<u32>;
     fn with_nb_threads(&self, threads: u32) -> T;
 }
-

--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -1,0 +1,175 @@
+extern crate uuid;
+use coin_cbc;
+
+use dsl::*;
+use dsl::LpExpression::*;
+use solvers::{Solution, SolverTrait, Status, WithMaxSeconds, WithNbThreads};
+use std::collections::HashMap;
+
+/// Solver that calls cbc through [rust bindings](https://github.com/KardinalAI/coin_cbc)
+#[derive(Debug, Clone)]
+pub struct NativeCbcSolver {
+    name: String,
+    threads: Option<u32>,
+    seconds: Option<u32>,
+}
+
+impl NativeCbcSolver {
+    pub fn new() -> NativeCbcSolver {
+        NativeCbcSolver {
+            name: "CbcNative".to_string(),
+            threads: None,
+            seconds: None,
+        }
+    }
+}
+
+impl WithMaxSeconds<NativeCbcSolver> for NativeCbcSolver {
+    fn max_seconds(&self) -> Option<u32> {
+        self.seconds
+    }
+    fn with_max_seconds(&self, seconds: u32) -> NativeCbcSolver {
+        NativeCbcSolver {
+            seconds: Some(seconds),
+            ..self.clone()
+        }
+    }
+}
+impl WithNbThreads<NativeCbcSolver> for NativeCbcSolver {
+    fn nb_threads(&self) -> Option<u32> {
+        self.threads
+    }
+    fn with_nb_threads(&self, threads: u32) -> NativeCbcSolver {
+        NativeCbcSolver {
+            threads: Some(threads),
+            ..self.clone()
+        }
+    }
+}
+
+fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>) {
+    match expr {
+        &ConsBin(LpBinary { ref name, .. })
+        | &ConsInt(LpInteger { ref name, .. })
+        | &ConsCont(LpContinuous { ref name, .. }) => {
+            println!("{:?}", (name.clone(), split_constant_and_expr(expr).0));
+            lst.push((name.clone(), split_constant_and_expr(expr).0));
+        }
+
+        MulExpr(val, ref e) =>
+            match **e {
+                ConsBin(LpBinary { ref name, .. })
+                | ConsInt(LpInteger { ref name, .. })
+                | ConsCont(LpContinuous { ref name, .. }) => {
+                    if let LitVal(lit) = *val.clone() {
+                        lst.push((name.clone(), lit))
+                    }
+                },
+                MulExpr(..) | AddExpr(..) => var_lit(&*e, lst),
+                _ => (),
+            }
+        &AddExpr(ref e1, ref e2) | &SubExpr(ref e1, ref e2) => {
+            var_lit(&*e1, lst);
+            var_lit(&*e2, lst);
+        }
+        _ => (),
+    }
+}
+
+fn always_literal(expr: &LpExpression) -> f64 {
+    match expr {
+        &LitVal(num) => num as f64,
+        _ => panic!("wrong generalization"),
+    }
+}
+
+fn add_variable(m: &mut coin_cbc::Model, expr: &LpExpression) -> coin_cbc::Col {
+    match expr {
+        ConsInt(LpInteger {
+            name: _,
+            lower_bound,
+            upper_bound,
+        }) => {
+            let col = m.add_integer();
+            if let Some(lb) = lower_bound {
+                m.set_col_lower(col, *lb as f64)
+            }
+            if let Some(ub) = upper_bound {
+                m.set_col_lower(col, *ub as f64)
+            }
+            col
+        }
+        ConsCont(LpContinuous {
+            name: _,
+            lower_bound,
+            upper_bound,
+        }) => {
+            let col = m.add_col();
+            if let Some(lb) = lower_bound {
+                m.set_col_lower(col, *lb as f64)
+            }
+            if let Some(ub) = upper_bound {
+                m.set_col_lower(col, *ub as f64)
+            }
+            col
+        }
+        ConsBin(_) => m.add_binary(),
+        _ => panic!("Unexpected LpExpression on LpProblem.variables()!"),
+    }
+}
+
+impl SolverTrait for NativeCbcSolver {
+    type P = LpProblem;
+
+    fn run<'a>(&self, problem: &'a Self::P) -> Result<Solution<'a>, String> {
+
+        let mut m = coin_cbc::Model::default();
+        // columns (variables)
+        let cols: HashMap<String, coin_cbc::Col> = problem
+            .variables()
+            .iter()
+            .map(|(name, expr)| (name.clone(), add_variable(&mut m, expr)))
+            .collect();
+        // rows (constraints)
+        problem.constraints.iter().for_each(|cons| {
+            let row = m.add_row();
+            let general = cons.generalize();
+            match general.1 {
+                Constraint::GreaterOrEqual => m.set_row_lower(row, always_literal(&general.2)),
+                Constraint::LessOrEqual => m.set_row_upper(row, always_literal(&general.2)),
+                Constraint::Equal => m.set_row_equal(row, always_literal(&general.2)),
+            }
+            let mut lst: Vec<_> = Vec::new();
+            var_lit(&general.0, &mut lst);
+            println!("{:?}", lst);
+            lst.iter()
+                .for_each(|(n, lit)| m.set_weight(row, cols[n], *lit as f64));
+        });
+        // objective
+        if let Some(objective) = &problem.obj_expr {
+            let mut lst: Vec<_> = Vec::new();
+            var_lit(&objective, &mut lst);
+            lst.iter()
+                .for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
+        }
+        m.set_obj_sense(match problem.objective_type {
+            LpObjective::Maximize => coin_cbc::Sense::Maximize,
+            LpObjective::Minimize => coin_cbc::Sense::Minimize,
+        });
+
+        let sol = m.solve();
+
+        let mut lst: Vec<_> = Vec::new();
+        var_lit(&(problem.obj_expr.clone().unwrap()), &mut lst);
+
+        Ok(Solution {
+            status: match sol.raw().status() {
+                coin_cbc::raw::Status::Finished => Status::Optimal,
+                coin_cbc::raw::Status::Abandoned => Status::Infeasible,
+                _ => Status::NotSolved,
+            },
+            results: cols.iter().map(|(name, col)| (name.to_owned(), sol.col(*col) as f32)).collect(),
+            related_problem: Some(problem),
+        })
+    }
+}

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -2,7 +2,7 @@ extern crate lp_modeler;
 
 use std::collections::HashMap;
 
-use lp_modeler::solvers::{CbcSolver, SolverTrait, Solution};
+use lp_modeler::solvers::{CbcSolver, SolverTrait, Solution, NativeCbcSolver};
 use lp_modeler::dsl::*;
 use lp_modeler::format::lp_format::LpFileFormat;
 
@@ -31,14 +31,11 @@ fn test_readme_example_1() {
     }
 
     let output1 = "\\ One Problem
-
 Maximize
   obj: 10 a + 20 b
-
 Subject To
   c1: 500 a + 1200 b + 1500 c <= 10000
   c2: a - b <= 0
-
 "
         .to_string();
     let output2 = problem.to_lp_file_format();
@@ -177,4 +174,46 @@ fn test_readme_example_2() {
     assert_eq!(*var_values.get("A_F").unwrap(), 1f32);
     assert_eq!(*var_values.get("B_E").unwrap(), 1f32);
     assert_eq!(*var_values.get("C_D").unwrap(), 1f32);
+}
+
+#[test]
+// as in https://github.com/KardinalAI/coin_cbc/blob/master/examples/knapsack.rs
+//
+// Maximize  5a + 3b + 2c + 7d + 4e
+// s.t.      2a + 8b + 4c + 2d + 5e <= 10
+fn cbc_native_optimal() {
+    let mut problem = LpProblem::new("Knapsack", LpObjective::Maximize);
+    let objective: HashMap<&str, f32> =
+        vec![("a", 5.0), ("b", 3.0), ("c", 2.0), ("d", 7.0), ("e", 4.0)]
+            .into_iter()
+            .collect();
+    let x: HashMap<&str, LpBinary> = objective
+        .iter()
+        .map(|(name, _)| (*name, LpBinary::new(name)))
+        .collect();
+        problem +=
+        (2.0 * &x["a"] + 8.0 * &x["b"] + 4.0 * &x["c"] + 2. * &x["d"] + 5. * &x["e"]).le(10.);
+    problem += 5.0 * &x["a"] + 3.0 * &x["b"] + 2.0 * &x["c"] + 7. * &x["d"] + 4. * &x["e"];
+
+    let solver = NativeCbcSolver::new();
+
+    match solver.run(&problem) {
+        Ok(sol) => {
+            println!("Status {:?}", sol.status);
+            println!("{:?}", sol.results);
+            assert_eq!(
+                16f32,
+                x.iter()
+                    .map(|(name, var)| match sol.results.get(&var.name) {
+                        Some(s) => {
+                            println!("{:?}*{}", s, objective.get(name).unwrap());
+                            s * objective.get(name).unwrap()
+                        }
+                        _ => 0.,
+                    })
+                    .sum()
+            );
+        }
+        Err(msg) => panic!("Native Cbc Solver panicked at run: {}", msg),
+    }
 }


### PR DESCRIPTION
Addresses #45 

### Description
This PR provides a new solver to call CoinOR CBC trough the C API.

### Implementation
The new struct [`NativeCBCSolver`](https://github.com/carrascomj/rust-lp-modeler/blob/master/src/solvers/native_cbc.rs#L11) implements `SolverTrait` and uses the rust bindings in https://github.com/KardinalAI/coin_cbc/. A different `NativeSolverTrait` should be considered to extend the functionality in the future.