### PR TITLE
Fix Substraction on NativeCBC

### DIFF
--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -52,7 +52,6 @@ fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>) {
         &ConsBin(LpBinary { ref name, .. })
         | &ConsInt(LpInteger { ref name, .. })
         | &ConsCont(LpContinuous { ref name, .. }) => {
-            println!("{:?}", (name.clone(), split_constant_and_expr(expr).0));
             lst.push((name.clone(), split_constant_and_expr(expr).0));
         }
 
@@ -139,7 +138,6 @@ impl SolverTrait for NativeCbcSolver {
             }
             let mut lst: Vec<_> = Vec::new();
             var_lit(&general.0, &mut lst);
-            println!("{:?}", lst);
             lst.iter()
                 .for_each(|(n, lit)| m.set_weight(row, cols[n], *lit as f64));
         });

--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -47,12 +47,17 @@ impl WithNbThreads<NativeCbcSolver> for NativeCbcSolver {
     }
 }
 
-fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>) {
+/// Recursively unwrap an expression in a Vec of variables and literals.
+fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>, mul: Option<f32>) {
+    let mul = match mul {
+        Some(lit) => lit,
+        None => 1.,
+    };
     match expr {
         &ConsBin(LpBinary { ref name, .. })
         | &ConsInt(LpInteger { ref name, .. })
         | &ConsCont(LpContinuous { ref name, .. }) => {
-            lst.push((name.clone(), split_constant_and_expr(expr).0));
+            lst.push((name.clone(), mul * split_constant_and_expr(expr).0));
         }
 
         MulExpr(val, ref e) => match **e {
@@ -60,15 +65,25 @@ fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>) {
             | ConsInt(LpInteger { ref name, .. })
             | ConsCont(LpContinuous { ref name, .. }) => {
                 if let LitVal(lit) = *val.clone() {
-                    lst.push((name.clone(), lit))
+                    lst.push((name.clone(), mul * lit))
                 }
             }
-            MulExpr(..) | AddExpr(..) => var_lit(&*e, lst),
+            MulExpr(..) | AddExpr(..) | SubExpr(..) => {
+                let next_mul = match *val.clone() {
+                    LitVal(lit) => Some(lit * mul),
+                    _ => None,
+                };
+                var_lit(&*e, lst, next_mul)
+            }
             _ => (),
         },
-        &AddExpr(ref e1, ref e2) | &SubExpr(ref e1, ref e2) => {
-            var_lit(&*e1, lst);
-            var_lit(&*e2, lst);
+        &AddExpr(ref e1, ref e2) => {
+            var_lit(&*e1, lst, None);
+            var_lit(&*e2, lst, None);
+        }
+        &SubExpr(ref e1, ref e2) => {
+            var_lit(&*e1, lst, None);
+            var_lit(&*e2, lst, Some(-1.));
         }
         _ => (),
     }
@@ -137,14 +152,14 @@ impl SolverTrait for NativeCbcSolver {
                 Constraint::Equal => m.set_row_equal(row, always_literal(&general.2)),
             }
             let mut lst: Vec<_> = Vec::new();
-            var_lit(&general.0, &mut lst);
+            var_lit(&general.0, &mut lst, None);
             lst.iter()
                 .for_each(|(n, lit)| m.set_weight(row, cols[n], *lit as f64));
         });
         // objective
         if let Some(objective) = &problem.obj_expr {
             let mut lst: Vec<_> = Vec::new();
-            var_lit(&objective, &mut lst);
+            var_lit(&objective, &mut lst, None);
             lst.iter()
                 .for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
         }
@@ -156,7 +171,7 @@ impl SolverTrait for NativeCbcSolver {
         let sol = m.solve();
 
         let mut lst: Vec<_> = Vec::new();
-        var_lit(&(problem.obj_expr.clone().unwrap()), &mut lst);
+        var_lit(&(problem.obj_expr.clone().unwrap()), &mut lst, None);
 
         Ok(Solution {
             status: match sol.raw().status() {

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -182,8 +182,8 @@ fn test_readme_example_2() {
 #[test]
 // as in https://github.com/KardinalAI/coin_cbc/blob/master/examples/knapsack.rs
 //
-// Maximize  5a + 3b + 2c + 7d + 4e
-// s.t.      2a + 8b + 4c + 2d + 5e <= 10
+// Maximize  5a + 3b + 2c + 7d - 4e
+// s.t.      2a - 8b + 4c + 2d + 5e <= 10
 fn cbc_native_optimal() {
     let mut problem = LpProblem::new("Knapsack", LpObjective::Maximize);
     let objective: HashMap<&str, f32> =
@@ -195,8 +195,8 @@ fn cbc_native_optimal() {
         .map(|(name, _)| (*name, LpBinary::new(name)))
         .collect();
         problem +=
-        (2.0 * &x["a"] + 8.0 * &x["b"] + 4.0 * &x["c"] + 2. * &x["d"] + 5. * &x["e"]).le(10.);
-    problem += 5.0 * &x["a"] + 3.0 * &x["b"] + 2.0 * &x["c"] + 7. * &x["d"] + 4. * &x["e"];
+        (2.0 * &x["a"] - 8.0 * &x["b"] + 4.0 * &x["c"] + 2. * &x["d"] + 5. * &x["e"]).le(10.);
+    problem += 5.0 * &x["a"] + 3.0 * &x["b"] + 2.0 * &x["c"] + 7. * &x["d"] + -4. * &x["e"];
 
     let solver = NativeCbcSolver::new();
 
@@ -205,7 +205,7 @@ fn cbc_native_optimal() {
             println!("Status {:?}", sol.status);
             println!("{:?}", sol.results);
             assert_eq!(
-                16f32,
+                17f32,
                 x.iter()
                     .map(|(name, var)| match sol.results.get(&var.name) {
                         Some(s) => {


### PR DESCRIPTION
Related to #45.
### Description
`SubExpr` were being unwrapped as with `AddExpr`.

### Implementation
Added an argument to the unwrapping function [`var_lit()`](https://github.com/carrascomj/rust-lp-modeler/blob/master/src/solvers/native_cbc.rs#L50) to account for multipliers to the whole expression. Then, substractions are passed with a `-1f32` multipler to the second expression.

* Changed the test to have SubExpr.  It is passing.
*  Still not working for, for instance, https://github.com/carrascomj/kair/tree/run-native (try `cargo test` on the _run-native_ branch). It needs further debuggin to see what's wrong.

The solution is not very elegant, maybe  the expressions themselves should be changed accordingly when passed recursively instead of adding a third argument.