### PR TITLE
Native Cbc as feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,5 +21,5 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
   

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,10 @@ travis-ci = { repository = "jcavat/rust-lp-modeler" }
 appveyor = { repository = "jcavat/rust-lp-modeler" }
 
 [dependencies]
-coin_cbc = "0.1.0"
+coin_cbc = { version = "0.1.0", optional = true }
 uuid = { version = "0.7.4", features = ["v4"] }
 quote = "1"
 proc-macro2 = "1.0"
+
+[features]
+native_cbc = ["coin_cbc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-extern crate uuid;
+#[cfg(feature = "native_cbc")]
+extern crate coin_cbc;
 extern crate proc_macro2;
 extern crate quote;
-extern crate coin_cbc;
+extern crate uuid;
 
 pub mod util;
 
@@ -15,7 +16,7 @@ pub mod dsl {
 }
 
 pub mod format {
-   pub mod lp_format;
+    pub mod lp_format;
 }
 
 pub mod solvers;

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -11,8 +11,11 @@ pub use self::gurobi::*;
 pub mod glpk;
 pub use self::glpk::*;
 
+#[cfg(feature = "native_cbc")]
 pub mod native_cbc;
+#[cfg(feature = "native_cbc")]
 pub use self::native_cbc::*;
+
 use std::fs::File;
 use std::fs;
 use util::is_zero;

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -2,7 +2,9 @@ extern crate lp_modeler;
 
 use std::collections::HashMap;
 
-use lp_modeler::solvers::{CbcSolver, SolverTrait, Solution, NativeCbcSolver};
+use lp_modeler::solvers::{CbcSolver, SolverTrait, Solution};
+#[cfg(feature = "native_cbc")]
+use lp_modeler::solvers::NativeCbcSolver;
 use lp_modeler::dsl::*;
 use lp_modeler::format::lp_format::LpFileFormat;
 
@@ -180,6 +182,7 @@ fn test_readme_example_2() {
 }
 
 #[test]
+#[cfg(feature = "native_cbc")]
 // as in https://github.com/KardinalAI/coin_cbc/blob/master/examples/knapsack.rs
 //
 // Maximize  5a + 3b + 2c + 7d - 4e


### PR DESCRIPTION
### Description
The [`coin_cbc`](https://github.com/KardinalAI/coin_cbc/) dependency, required for `NativeCBCSolver`, fails to build on systems that do not have [`coin-or Cbc`](https://github.com/coin-or/Cbc). This limits the use of the library for other solvers.

### Implementation
Separate the `NativeCbcSolver` with its dependency as a **non-default [feature](https://doc.rust-lang.org/cargo/reference/features.html) called native_cbc**.