### PR TITLE
Fix bounds native cbc

### DIFF
--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -108,7 +108,7 @@ fn add_variable(m: &mut coin_cbc::Model, expr: &LpExpression) -> coin_cbc::Col {
                 m.set_col_lower(col, *lb as f64)
             }
             if let Some(ub) = upper_bound {
-                m.set_col_lower(col, *ub as f64)
+                m.set_col_upper(col, *ub as f64)
             }
             col
         }
@@ -122,7 +122,7 @@ fn add_variable(m: &mut coin_cbc::Model, expr: &LpExpression) -> coin_cbc::Col {
                 m.set_col_lower(col, *lb as f64)
             }
             if let Some(ub) = upper_bound {
-                m.set_col_lower(col, *ub as f64)
+                m.set_col_upper(col, *ub as f64)
             }
             col
         }
@@ -160,8 +160,7 @@ impl SolverTrait for NativeCbcSolver {
         if let Some(objective) = &problem.obj_expr {
             let mut lst: Vec<_> = Vec::new();
             var_lit(&objective, &mut lst, None);
-            lst.iter()
-                .for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
+            lst.iter().for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
         }
         m.set_obj_sense(match problem.objective_type {
             LpObjective::Maximize => coin_cbc::Sense::Maximize,
@@ -169,9 +168,6 @@ impl SolverTrait for NativeCbcSolver {
         });
 
         let sol = m.solve();
-
-        let mut lst: Vec<_> = Vec::new();
-        var_lit(&(problem.obj_expr.clone().unwrap()), &mut lst, None);
 
         Ok(Solution {
             status: match sol.raw().status() {

--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -57,7 +57,9 @@ fn var_lit(expr: &LpExpression, lst: &mut Vec<(String, f32)>, mul: Option<f32>) 
         &ConsBin(LpBinary { ref name, .. })
         | &ConsInt(LpInteger { ref name, .. })
         | &ConsCont(LpContinuous { ref name, .. }) => {
-            lst.push((name.clone(), mul * split_constant_and_expr(expr).0));
+            let coeff = split_constant_and_expr(expr).0;
+            let coeff = if coeff == 0. { mul } else { mul * coeff };
+            lst.push((name.clone(), coeff));
         }
 
         MulExpr(val, ref e) => match **e {

--- a/src/solvers/native_cbc.rs
+++ b/src/solvers/native_cbc.rs
@@ -162,7 +162,8 @@ impl SolverTrait for NativeCbcSolver {
         if let Some(objective) = &problem.obj_expr {
             let mut lst: Vec<_> = Vec::new();
             var_lit(&objective, &mut lst, None);
-            lst.iter().for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
+            lst.iter()
+                .for_each(|(n, lit)| m.set_obj_coeff(cols[n], *lit as f64))
         }
         m.set_obj_sense(match problem.objective_type {
             LpObjective::Maximize => coin_cbc::Sense::Maximize,


### PR DESCRIPTION
Closes #55 

### Description
[NativeCbcSolver](https://github.com/jcavat/rust-lp-modeler/blob/master/src/solvers/native_cbc.rs) was giving wrong results for problems which were relatively easy (for instance, [this one](https://github.com/carrascomj/kair/blob/trunk/examples/ecoli.rs)).

### Solution
There were two stupid bugs introduced by a certain me:
* Variables without an associated literal value were added to the constraints or objective expressions with a 0 coefficient. Solved by adding a default coefficient of 1.
* Upper bounds in variables were assigned as lower bound.