### PR TITLE
Add {Add,Sub,Mul}Assign implementations for LpExpression (and fix EmptyExpr handling)

### DIFF
--- a/src/dsl/operations.rs
+++ b/src/dsl/operations.rs
@@ -1,6 +1,6 @@
-use std::ops::{Add, Mul, Neg, Sub};
 use dsl::LpExpression::*;
 use dsl::{Constraint, LpBinary, LpConstraint, LpContinuous, LpExpression, LpInteger};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// Operations trait for any type implementing Into<LpExpressions> trait
 pub trait LpOperations<T> where T: Into<LpExpression> {
@@ -67,6 +67,23 @@ macro_rules! operations_for_expr {
 operations_for_expr!(Add, add, AddExpr);
 operations_for_expr!(Sub, sub, SubExpr);
 operations_for_expr!(Mul, mul, MulExpr);
+
+macro_rules! assign_operations_for_expr {
+    ($trait_name: ident, $f_name: ident, $expr_type: ident) => {
+        impl<T> $trait_name<T> for LpExpression
+        where
+            T: Into<LpExpression> + Clone,
+        {
+            fn $f_name(&mut self, _rhs: T) {
+                *self = $expr_type(Box::new(self.clone()), Box::new(_rhs.into()));
+            }
+        }
+    };
+}
+
+assign_operations_for_expr!(AddAssign, add_assign, AddExpr);
+assign_operations_for_expr!(SubAssign, sub_assign, SubExpr);
+assign_operations_for_expr!(MulAssign, mul_assign, MulExpr);
 
 /// Macro implementing a binary operation with a LpVars and a Into<Expression>
 macro_rules! lpvars_operation_for_intoexpr {

--- a/src/dsl/variables.rs
+++ b/src/dsl/variables.rs
@@ -508,7 +508,7 @@ pub fn simplify(expr: &LpExpression) -> LpExpression {
             &ConsInt(LpInteger { .. }) => expr.clone(),
             &ConsCont(LpContinuous { .. }) => expr.clone(),
             &LitVal(_) => expr.clone(),
-            _ => expr.clone(),
+            &EmptyExpr => LitVal(0.0),
         }
     }
 


### PR DESCRIPTION
The traits `AddAssign`, `SubAssign`, and `MulAssign` are implemented for `LpExpression`, like the traits `Add`, `Sub`, and `Mul` are already.

To make all of the mentioned traits (old and new) work for the base expression `EmptyExpr`, this expression is now handled in `simplify()`; it is treated as a zero constant. This way, expressions like `AddExpr(EmptyExpr, ...)` just work as expected.

As there were no tests for the changed code, no further tests are added. 