### PR TITLE
newline before comparison operator in .lp file format

### DIFF
--- a/src/format/lp_format.rs
+++ b/src/format/lp_format.rs
@@ -164,7 +164,7 @@ impl LpFileFormat for LpConstraint {
     fn to_lp_file_format(&self) -> String {
         let mut res = String::new();
         res.push_str(&self.0.to_lp_file_format());
-        res.push_str(&"\n");
+        res.push_str(&"\n   ");
         match self.1 {
             GreaterOrEqual => res.push_str(" >= "),
             LessOrEqual => res.push_str(" <= "),

--- a/src/format/lp_format.rs
+++ b/src/format/lp_format.rs
@@ -164,6 +164,7 @@ impl LpFileFormat for LpConstraint {
     fn to_lp_file_format(&self) -> String {
         let mut res = String::new();
         res.push_str(&self.0.to_lp_file_format());
+        res.push_str(&"\n");
         match self.1 {
             GreaterOrEqual => res.push_str(" >= "),
             LessOrEqual => res.push_str(" <= "),

--- a/tests/expression.rs
+++ b/tests/expression.rs
@@ -130,25 +130,25 @@ fn expressions_to_lp_file_format() {
     assert_eq!((-2 * a).to_lp_file_format(), "-2 a");
 
     // Constraints
-    assert_eq!((a + b).equal(10).to_lp_file_format(), "a + b = 10");
-    assert_eq!((2 * a + b).ge(10).to_lp_file_format(), "2 a + b >= 10");
+    assert_eq!((a + b).equal(10).to_lp_file_format(), "a + b\n    = 10");
+    assert_eq!((2 * a + b).ge(10).to_lp_file_format(), "2 a + b\n    >= 10");
     assert_eq!(
         (2 * a + b + 20).ge(c).to_lp_file_format(),
-        "2 a + b - c >= -20"
+        "2 a + b - c\n    >= -20"
     );
-    assert_eq!((-a).ge(10).to_lp_file_format(), "-a >= 10");
+    assert_eq!((-a).ge(10).to_lp_file_format(), "-a\n    >= 10");
     assert_eq!(
         (2 * a - 20 + b).ge(-c).to_lp_file_format(),
-        "2 a + b + c >= 20"
+        "2 a + b + c\n    >= 20"
     );
-    assert_eq!((a + b + 10).ge(0).to_lp_file_format(), "a + b >= -10");
+    assert_eq!((a + b + 10).ge(0).to_lp_file_format(), "a + b\n    >= -10");
     assert_eq!(
         (3 * (a + b + 10)).le(0).to_lp_file_format(),
-        "3 a + 3 b <= -30"
+        "3 a + 3 b\n    <= -30"
     );
     assert_eq!(
         (3 * (a + b + 10)).le(a + b).to_lp_file_format(),
-        "3 a + 3 b - a - b <= -30"
+        "3 a + 3 b - a - b\n    <= -30"
     );
 }
 
@@ -165,15 +165,15 @@ fn expression_with_lp_sum() {
     let ref empty: Vec<&LpBinary> = vec!();
     assert_eq!(
         lp_sum(expr1).equal(10.0).to_lp_file_format(),
-        "a + b + c = 10"
+        "a + b + c\n    = 10"
     );
     assert_eq!(
         lp_sum(expr2).equal(10.0).to_lp_file_format(),
-        "a + b + c + d = 10"
+        "a + b + c + d\n    = 10"
     );
     assert_eq!(
         lp_sum(expr3).le(5.5).to_lp_file_format(),
-        "a <= 5.5"
+        "a\n    <= 5.5"
     );
     assert_eq!(
         lp_sum(empty).to_lp_file_format(),
@@ -190,6 +190,6 @@ fn macros(){
 
     assert_eq!(
         constraint!(2 * a + b + 20 >= c).to_lp_file_format(),
-        "2 a + b - c >= -20"
+        "2 a + b - c\n    >= -20"
     );
 }

--- a/tests/problems.rs
+++ b/tests/problems.rs
@@ -38,8 +38,10 @@ Maximize
   obj: 10 a + 20 b
 
 Subject To
-  c1: 500 a + 1200 b + 1500 c <= 10000
-  c2: a - b <= 0
+  c1: 500 a + 1200 b + 1500 c
+    <= 10000
+  c2: a - b
+    <= 0
 
 "
         .to_string();


### PR DESCRIPTION
This is a workaround for this curious cbc bug that I encountered:
https://github.com/coin-or/CoinUtils/issues/144

It seems that [the `LP` file format is not standardized](https://support.gurobi.com/hc/en-us/articles/360013195612) (yay!). However, [points 5 and 9 in this lpsolve documentation for the CPLEX `LP` format](https://web.mit.edu/lpsolve/doc/CPLEX-format.htm) and this [IBM CPLEX `LP` format description of constraints](https://www.ibm.com/support/knowledgecenter/SSSA5P_12.8.0/ilog.odms.cplex.help/CPLEX/FileFormats/topics/LP_Constraints.html) agree in that constraints can go across multiple lines. Only the constraint name and its colon (e.g. `c1234:`) need to appear on the same line, as do the comparison operator and the right-hand side (e.g. `>= 5678`). And I found [this slide deck](https://coral.ise.lehigh.edu/~ted/files/coin-or/slides/COINModeling.pdf) that refers to the `LP` file format as developed by CPLEX. So I assume cbc (and the other solvers) will follow these kinds of "format descriptions".

So introducing these newlines should be safe to do and will prevent this bug. To get back the original format, this PR can later be reverted once the issue in CoinUtils (and thus cbc) is addressed. To make this easier, I would squash the commits in this PR during merging.