### PR TITLE
add newline after End statement in .lp files

### DIFF
--- a/src/format/lp_format.rs
+++ b/src/format/lp_format.rs
@@ -44,7 +44,7 @@ impl LpFileFormat for LpProblem {
             buffer.push_str(format!("\nBinary\n  {}\n", &binaries_block).as_str());
         }
 
-        buffer.push_str("\nEnd");
+        buffer.push_str("\nEnd\n");
 
         buffer
     }


### PR DESCRIPTION
This gives correct(er) files that are properly ended. And it should help with this cbc input parsing problem until it is fixed:

https://github.com/coin-or/CoinUtils/issues/145